### PR TITLE
修复并发id重复的问题

### DIFF
--- a/internal/biz/model/segment.go
+++ b/internal/biz/model/segment.go
@@ -25,12 +25,14 @@ func NewSegment(segmentBuffer *SegmentBuffer) *Segment {
 	return s
 }
 
-func (s *Segment) GetValue() *atomic.Int64 {
-	return s.Value
+func (s *Segment) GetValue() int64 {
+	return s.Value.Load()
 }
-
-func (s *Segment) SetValue(value *atomic.Int64) {
-	s.Value = value
+func (s *Segment) Inc() int64 {
+	return s.Value.Inc()
+}
+func (s *Segment) SetValue(value int64) {
+	s.Value.Store(value)
 }
 
 func (s *Segment) GetMax() int64 {
@@ -50,7 +52,7 @@ func (s *Segment) SetStep(step int) {
 }
 
 func (s *Segment) GetIdle() int64 {
-	value := s.GetValue().Load()
+	value := s.Value.Load()
 	return s.GetMax() - value
 }
 


### PR DESCRIPTION
以下这种写法,会在并发的时候造成边界问题,从而引起id重复
```
value = segment.GetValue().Load()
segment.GetValue().Inc()
```
已修正,把两步合并为一步